### PR TITLE
php-md 2.7 compat

### DIFF
--- a/src/framework-app-search/Document/SyncManager.php
+++ b/src/framework-app-search/Document/SyncManager.php
@@ -19,6 +19,8 @@ use Ramsey\Uuid\UuidFactory;
 /**
  * Implementation of the sync manager component.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Framework\AppSearch\Document
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -67,8 +69,6 @@ class SyncManager implements SyncManagerInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param BatchDataMapperResolverInterface $batchDataMapperResolver
      * @param ConnectionManagerInterface       $connectionManager

--- a/src/framework-app-search/SearchAdapter/RequestExecutor/Facet/ResponseProcessor.php
+++ b/src/framework-app-search/SearchAdapter/RequestExecutor/Facet/ResponseProcessor.php
@@ -20,6 +20,7 @@ use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\Response\DocumentCountRe
  * Process facet from the App Search response.
  *
  * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
+ * @SuppressWarnings(PHPMD.LongVariable)
  *
  * @package   Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\Facet
  * @copyright 2019 Elastic
@@ -44,8 +45,6 @@ class ResponseProcessor implements ResponseProcessorInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param DocumentCountResolver $documentCountResolver
      * @param AlgorithmInterface[]  $algorithms

--- a/src/framework-app-search/SearchAdapter/RequestExecutor/Filter/SearchParamsProvider.php
+++ b/src/framework-app-search/SearchAdapter/RequestExecutor/Filter/SearchParamsProvider.php
@@ -17,6 +17,8 @@ use Elastic\AppSearch\Framework\AppSearch\Engine\Field\FieldMapperResolverInterf
 /**
  * Extract and build filters from the search request.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\Filter
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -40,8 +42,6 @@ class SearchParamsProvider implements SearchParamsProviderInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param QueryFilterBuilderInterfaceFactory $queryFilterBuilderFactory
      * @param FieldMapperResolverInterface       $fieldMapperResolver

--- a/src/framework-app-search/SearchAdapter/Response/AggregationBuilder.php
+++ b/src/framework-app-search/SearchAdapter/Response/AggregationBuilder.php
@@ -20,6 +20,8 @@ use Magento\Framework\Search\Response\Aggregation\Value as AggregationValue;
 /**
  * Build response aggregation from the App Search response.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Framework\AppSearch\SearchAdapter\Response
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -43,8 +45,6 @@ class AggregationBuilder
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param AggregationFactory      $aggregationFactory
      * @param BucketFactory           $bucketFactory

--- a/src/framework-app-search/SearchAdapter/Response/DocumentFactory.php
+++ b/src/framework-app-search/SearchAdapter/Response/DocumentFactory.php
@@ -18,6 +18,8 @@ use Magento\Framework\Api\CustomAttributesDataInterface;
 /**
  * App Search search adapter response document factory.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Framework\AppSearch\SearchAdapter\Response
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -36,8 +38,6 @@ class DocumentFactory
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param BaseDocumentFactory   $documentFactory
      * @param AttributeValueFactory $attributeValueFactory

--- a/src/framework-app-search/SearchAdapter/ResponseBuilder.php
+++ b/src/framework-app-search/SearchAdapter/ResponseBuilder.php
@@ -19,6 +19,8 @@ use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\Response\DocumentCountRe
 /**
  * AppSearch search adapter response factory implementation.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Framework\AppSearch\SearchAdapter
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -47,8 +49,6 @@ class ResponseBuilder
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param ResponseFactory         $responseFactory
      * @param DocumentFactory         $documentFactory

--- a/src/framework-app-search/Test/Unit/SearchAdapter/RequestExecutorTest.php
+++ b/src/framework-app-search/Test/Unit/SearchAdapter/RequestExecutorTest.php
@@ -18,7 +18,6 @@ use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\EngineRe
 use Elastic\AppSearch\Framework\AppSearch\EngineInterface;
 use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\SearchParamsProviderInterface;
 use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\Fulltext\QueryTextResolverInterface;
-use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\RescorerResolverInterface;
 use Elastic\AppSearch\Framework\AppSearch\SearchAdapter\RequestExecutor\ResponseProcessorInterface;
 
 /**
@@ -63,6 +62,8 @@ class RequestExecutorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test client exception handling.
+     *
+     * @SuppressWarnings(PHPMD.MissingImport)
      */
     public function testExceptionHandling()
     {

--- a/src/module-catalog-graph-ql/Model/Resolver/Products.php
+++ b/src/module-catalog-graph-ql/Model/Resolver/Products.php
@@ -23,6 +23,8 @@ use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 /**
  * AppSearch search GraphQL products resolver.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @deprecated Will be removed when Magento GraphQL implementation will have better support for sort / pagination.
  *
  * @package   Elastic\AppSearch\CatalogGraphQl\Model\Resolver
@@ -53,8 +55,6 @@ class Products implements ResolverInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param SearchQuery           $searchQuery
      * @param SearchFilter          $searchFilter

--- a/src/module-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -24,6 +24,8 @@ use Elastic\AppSearch\CatalogGraphQl\Model\Layer\CollectionProvider;
 /**
  * Run search for the products resolver.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @deprecated Will be removed when Magento GraphQL implementation will have better support for sort / pagination.
  *
  * @package   Elastic\AppSearch\CatalogGraphQl\Model\Resolver\Products\Query

--- a/src/module-catalog-search/Model/Product/Engine/Field/AttributeFieldProvider.php
+++ b/src/module-catalog-search/Model/Product/Engine/Field/AttributeFieldProvider.php
@@ -19,6 +19,8 @@ use Magento\Catalog\Api\Data\ProductAttributeInterface;
 /**
  * Retrieve engine fields from product EAV attributes.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\CatalogSearch\Model\Product\Engine\Field
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -42,8 +44,6 @@ class AttributeFieldProvider implements FieldProviderInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param AttributeDataProvider $attributeDataProvider
      * @param AttributeFieldFactory $fieldFactory

--- a/src/module-catalog-search/Model/Product/Engine/Schema/PriceSchemaProvider.php
+++ b/src/module-catalog-search/Model/Product/Engine/Schema/PriceSchemaProvider.php
@@ -23,6 +23,8 @@ use Magento\CatalogSearch\Model\Indexer\Fulltext;
 /**
  * Price fields for the product schema.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\CatalogSearch\Model\Product\Engine\Schema
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -56,8 +58,6 @@ class PriceSchemaProvider implements SchemaProviderInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param SchemaBuilderInterface           $schemaBuilder
      * @param FieldMapperResolverInterface     $fieldMapperResolver

--- a/src/module-catalog-search/Model/Product/SearchAdapter/RequestExecutor/Rescorer/CategoryPositionProvider.php
+++ b/src/module-catalog-search/Model/Product/SearchAdapter/RequestExecutor/Rescorer/CategoryPositionProvider.php
@@ -90,9 +90,10 @@ class CategoryPositionProvider
      */
     public function getPositionedDocuments(RequestInterface $request): array
     {
-        $docIds = [];
+        $docIds     = [];
+        $categoryId = $this->getCategoryId($request);
 
-        if ($categoryId = $this->getCategoryId($request)) {
+        if ($categoryId) {
             $storeId  = $this->getStoreId($request);
             $cacheKey = $categoryId . '_' . $storeId;
 

--- a/src/module-catalog-search/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-catalog-search/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -21,6 +21,7 @@ use Elastic\AppSearch\CatalogSearch\Model\Config as AppSearchConfig;
  * @deprecated Will be removed when dropping compat. with Magento < 2.4.x.
  *
  * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+ * @SuppressWarnings(PHPMD.LongVariable)
  *
  * @package   Elastic\AppSearch\CatalogSearch\Model\ResourceModel\Product\Fulltext
  * @copyright 2019 Elastic
@@ -97,8 +98,6 @@ class Collection extends \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Col
 
     // phpcs:disable
     /**
-     * @SuppressWarnings(PHPMD.LongVariable)
-     *
      * {@inheritDoc}
      */
     protected function _renderFiltersBefore()

--- a/src/module-search/Model/Search.php
+++ b/src/module-search/Model/Search.php
@@ -21,6 +21,8 @@ use Magento\Framework\Search\SearchEngineInterface;
  *
  * @deprecated Will be removed when dropping compat. with Magento < 2.4.x.
  *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ *
  * @package   Elastic\AppSearch\Search\Model
  * @copyright 2019 Elastic
  * @license   Open Software License ("OSL") v. 3.0
@@ -44,8 +46,6 @@ class Search implements SearchInterface
 
     /**
      * Constructor.
-     *
-     * @SuppressWarnings(PHPMD.LongVariable)
      *
      * @param RequestBuilder        $requestBuilder
      * @param SearchEngineInterface $searchEngine

--- a/src/module-synonyms/Model/Indexer.php
+++ b/src/module-synonyms/Model/Indexer.php
@@ -77,6 +77,8 @@ class Indexer implements
     }
 
     /**
+     * @SuppressWarnings(PHPMD.MissingImport)
+     *
      * {@inheritDoc}
      */
     public function executeByDimensions(array $dimensions, \Traversable $entityIds = null)

--- a/src/module-synonyms/Model/Indexer/IndexerHandlerFactory.php
+++ b/src/module-synonyms/Model/Indexer/IndexerHandlerFactory.php
@@ -58,6 +58,8 @@ class IndexerHandlerFactory
     /**
      * Create indexer handler
      *
+     * @SuppressWarnings(PHPMD.MissingImport)
+     *
      * @param array $data
      *
      * @return IndexerInterface


### PR DESCRIPTION
Test fails because phpmd 2.7 is now more strict on:
- private fields name length
- assignation in if clause
- imported classes