### PR TITLE
Better sync management process.

### DIFF
--- a/src/framework-app-search/Document/SyncManager.php
+++ b/src/framework-app-search/Document/SyncManager.php
@@ -206,7 +206,7 @@ class SyncManager implements SyncManagerInterface
                     usleep(200);
                 }
                 $resp = $this->client->search($engineName, '', $searchParams);
-                $attempts --;
+                $attempts--;
             } while ($attempts > 0 && $resp['meta']['page']['total_results'] < $expectedCount);
         }
     }

--- a/src/module-catalog-search/etc/crontab.xml
+++ b/src/module-catalog-search/etc/crontab.xml
@@ -18,7 +18,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="index">
         <job name="app_search_purge_deleted_documents" instance="Elastic\AppSearch\CatalogSearch\Cron\PurgeDeletedProducts" method="execute">
-            <schedule>* * * * *</schedule>
+            <schedule>0 * * * *</schedule>
         </job>
     </group>
 </config>


### PR DESCRIPTION
Improve the sync manager to:
- tag search requests used to wait for indexed documents to be searchable
- tag search requests used by document purge
- add a max number of attempts when waiting for the documents to be searchable